### PR TITLE
Update pom.xml

### DIFF
--- a/security-ldap/pom.xml
+++ b/security-ldap/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.backbase.portal.foundation</groupId>
             <artifactId>business</artifactId>
-            <version>${portal.bom.version}</version>
+            <version>${portal.server.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
${portal.integration.version} is not in the archetype anymore, exercises fail in build time. All the exercises should be tested with all the new version of the archetype